### PR TITLE
Preference attribute

### DIFF
--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -1,0 +1,165 @@
+# Changes
+This repository contains a fork of the repository of the [INET framework](https://github.com/inet-framework/inet) for [OMNeT++](https://omnetpp.org). We have adapted a few things, mainly with respect to MPLS. The goal is to provide an implementation that allows the simulation of MPLS traffic with a pre-existing data plane. To achieve this, we have modified a couple of classes and files.
+
+Although the simulations work as intended and we have achieved our goal, we cannot guarantee that these modifications do not break other classes that we currently are not using. Use our code at your own risk!
+
+**Features:**
+
+* Priority stack for MPLS forwarding rules
+* ECMP
+* Some fixes ...
+
+## Details
+* **Implement priority tag for the `LibTable` module**  
+We allow the MPLS `LibTable` to contain multiple entries for the same label with different priorities. This enables to install backup paths. The entry with the *lowest* integer value in the `priority` field for that the outgoing interface is `UP` is chosen for forwarding.  
+Please note, that the `LibTable::installLibEntry` has an additional (optional) parameter `int priority` with default value `0`. Also note, that the internal data structure of the `LibTable` class has changed.
+
+* **ECMP for MPLS forwarding rules** in the `LibTable` module  
+The traffic is equally distributed over all paths (ECMP) if there are multiple entries in the `LibTable` that have an equal `priority` value. Again, we only use those rules where the outging interfaces are `UP`.
+
+* **Multiple loopback interfaces**  
+We support multiple loopback interfaces at routers. The first loopback interface (usually `lo0`) has IP address `127.0.0.1`, the second one `127.0.0.2` and so on. (Modified files: `Ipv4NodeConfigurator.h` and `Ipv4NodeConfigurator.cc`)
+
+* **New router module `MplsRouter`**  
+The new router class is a copy of `RsvpMplsRouter.ned`, but with an additional loopback interface called `mlo0` that is connected to the `ml` message dispatcher. This allows the MPLS module to reroute traffic via a loopback interface. We need this to also allow those `pop` operations where the next label must be processed at the same router.
+
+* **Handling of ICMPv4 packets**  
+When using the `ScenarioManager` to simulate link fails, the IP module sends ICMPv4 packets to the (local) **RsvpTe** and **LinkStateRouting** module when it has no remaining (valid) route to the destination. However, these classes could not handle such packets, so that the simulations crashed.  
+We currently added code to just ignore such `ICMPv4` packets. A more advanced handling should, however, be added in the future!
+
+* `Mpls.cc` replaces a loopback interface ID before forwarding the packet to the IP module by the first non-loopback interface ID. This was required to get the last POP operation working.
+
+* **`RsvpClassifier.cc` pushes the label**  
+The `RsvpClassifier` now actually pushes the label onto the stack. (Method: `RsvpClassifier::lookupLabel`)
+
+* Note: `LibTable::resolveLabel()` currently ignores the `inInterface` parameter. See commit `@9dd425af76030bc21a7d0d44a2fb3aa27cb4c644`. To be fixed.
+
+Additionally, some logging messages were added for debugging purposes.
+
+## Usage
+1. Create an `omnetpp.ini` file:
+```
+[General]
+network = test_export
+sim-time-limit = 6s
+**.R1.libTable.config = xmldoc("R1_lib.xml")
+**.R2.libTable.config = xmldoc("R2_lib.xml")
+**.R3.libTable.config = xmldoc("R3_lib.xml")
+**.R4.libTable.config = xmldoc("R4_lib.xml")
+**.R5.libTable.config = xmldoc("R5_lib.xml")
+**.rsvp.helloInterval = 0.2s
+**.rsvp.helloTimeout = 0.5s
+**.ppp[*].queue.typename = "DropTailQueue"
+**.ppp[*].queue.packetCapacity = 10
+
+# The classification files that determine which label to add to packets
+**.R1.classifier.config = xmldoc("R1_classification.xml")
+**.R2.classifier.config = xmldoc("R2_classification.xml")
+**.R3.classifier.config = xmldoc("R3_classification.xml")
+**.R4.classifier.config = xmldoc("R4_classification.xml")
+**.R5.classifier.config = xmldoc("R5_classification.xml")
+
+# If you want to fail links, for example ...
+*.scenarioManager.script = xmldoc("scenario.xml")
+
+[Config UDP]
+**.host1.numApps = 1
+**.host1.app[0].typename = "UdpBasicApp"
+**.host1.app[0].localPort = 1000
+**.host1.app[0].destPort = 1000
+**.host1.app[0].messageLength = 64 bytes
+**.host1.app[0].sendInterval = 0.01s
+**.host1.app[0].destAddresses = "target1"
+
+**.target1.numApps = 1
+**.target1.app[0].typename = "UdpSinkApp"
+**.target1.app[0].io.localPort = 1000
+# ...
+```
+
+2. Add a topology in a `package.ned` file:
+```
+package inet.examples.mpls.frrtest;
+import inet.common.scenario.ScenarioManager;
+import inet.networklayer.configurator.ipv4.Ipv4NetworkConfigurator;
+import inet.node.inet.StandardHost;
+import inet.node.mpls.MplsRouter;
+
+network test_export
+{
+    submodules:
+        configurator: Ipv4NetworkConfigurator;
+        scenarioManager: ScenarioManager;
+        R1: MplsRouter {
+            parameters:
+                peers = "ppp0 ppp1";
+            gates:
+                pppg[5];
+        }
+        # other routers, ...
+        host1: StandardHost {
+            gates:
+                pppg[1];
+        }
+        # other hosts ...
+	connections:
+        R1.pppg[0] <--> { delay = 10ms; datarate = 1048576kbps; } <--> R2.pppg[0];
+        # additional connections ...
+}
+```
+
+3. The lib XML files (e.g. `R1_lib.xml`) contain the MPLS rules for the `LibTable`:  
+```
+<libtable>
+  <!-- POP via loopback, then process next label -->
+  <libentry>
+    <priority>0</priority>
+    <inLabel>3</inLabel>
+    <inInterface>any</inInterface>
+    <outInterface>mlo0</outInterface>
+    <outLabel>
+      <op code="pop" />
+    </outLabel>
+  </libentry>
+  <!-- POP and forward packet -->
+  <libentry>
+    <priority>0</priority>
+    <inLabel>17</inLabel>
+    <inInterface>any</inInterface>
+    <outInterface>ppp0</outInterface>
+    <outLabel>
+      <op code="pop" />
+    </outLabel>
+  </libentry>
+  <!-- use the same priority to use ECMP -->
+  <!-- use a higher value for priority to define a backup rule -->
+  <libentry>
+    <priority>1</priority>
+    <inLabel>17</inLabel>
+    <inInterface>any</inInterface>
+    <outInterface>ppp1</outInterface>
+    <outLabel>
+      <op code="pop" />
+      <op code="push" value="16" />
+    </outLabel>
+  </libentry>
+  <!-- other rules -->
+<libtable>
+```
+
+4. The classification files look like this (`R1_classification.xml`). All packets sent from `host1` with destination `target1` will get assigned the label `17` in this example:  
+```
+<fectable>
+  <fecentry>
+    <id>1</id>
+    <label>17</label>
+    <destination>target1</destination>
+    <source>host1</source>
+  </fecentry>
+</fectable>
+```
+
+
+## Contact
+Feel free to get in contact with me.  
+Nikolaus Suess &lt;nikolaus.suess@univie.ac.at&gt;

--- a/CHANGES.MD
+++ b/CHANGES.MD
@@ -32,8 +32,6 @@ We currently added code to just ignore such `ICMPv4` packets. A more advanced ha
 * **`RsvpClassifier.cc` pushes the label**  
 The `RsvpClassifier` now actually pushes the label onto the stack. (Method: `RsvpClassifier::lookupLabel`)
 
-* Note: `LibTable::resolveLabel()` currently ignores the `inInterface` parameter. See commit `@9dd425af76030bc21a7d0d44a2fb3aa27cb4c644`. To be fixed.
-
 Additionally, some logging messages were added for debugging purposes.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ WORK CORRECTLY, AND YOU'RE GETTING VALID RESULTS.
 Contributions are highly welcome. You can make a difference!
 
 > **Note**<br>
-> This repository is a fork of the [INET repository](https://github.com/inet-framework/inet). We have adapted a few things, mainly with respect to MPLS. The goal is to provide an implementation that allows the simulation of MPLS traffic with a pre-existing data plane. To achieve this, we have modified a couple of classes and files.<br>
-> Features:<br>
-> - Priority stack for MPLS forwarding rules<br>
-> - ECMP<br>
-> - Some fixes ...<br>
+> This repository is a fork of the [INET repository](https://github.com/inet-framework/inet). We have adapted a few things, mainly with respect to MPLS. The goal is to provide an implementation that allows the simulation of MPLS traffic with a pre-existing data plane. To achieve this, we have modified a couple of classes and files.
+> 
+> Features:
+> - Priority stack for MPLS forwarding rules
+> - ECMP
+> - Some fixes ...
+> 
 > See file [CHANGES.MD](CHANGES.MD) for details.
 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![badge 1][badge-1]][1] [![badge 2][badge-2]][2]
+<!-- [![badge 1][badge-1]][1] [![badge 2][badge-2]][2] -->
 
 INET Framework for OMNEST/OMNeT++
 =================================
@@ -17,7 +17,9 @@ WORK CORRECTLY, AND YOU'RE GETTING VALID RESULTS.
 
 Contributions are highly welcome. You can make a difference!
 
-See the WHATSNEW file for recent changes.
+> **Note**
+> This repository is a fork of the [INET repository](https://github.com/inet-framework/inet). We have adapted a few things, mainly with respect to MPLS. The goal is to provide an implementation that allows the simulation of MPLS traffic with a pre-existing data plane. To achieve this, we have modified a couple of classes and files. See file [CHANGES.MD](CHANGES.MD) for details.
+
 
 
 GETTING STARTED
@@ -51,9 +53,3 @@ If you want to use external interfaces in INET, enable the "Emulation" feature
 either in the IDE or using the inet_featuretool then regenerate the INET makefile
 using 'make makefiles'.
 
-
-[badge-1]: https://github.com/inet-framework/inet/workflows/Build%20and%20tests/badge.svg?branch=master
-[badge-2]: https://github.com/inet-framework/inet/workflows/Feature%20tests/badge.svg?branch=master
-
-[1]: https://github.com/inet-framework/inet/actions?query=workflow%3A%22Build+and+tests%22
-[2]: https://github.com/inet-framework/inet/actions?query=workflow%3A%22Feature+tests%22

--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ WORK CORRECTLY, AND YOU'RE GETTING VALID RESULTS.
 
 Contributions are highly welcome. You can make a difference!
 
-> **Note**
-> This repository is a fork of the [INET repository](https://github.com/inet-framework/inet). We have adapted a few things, mainly with respect to MPLS. The goal is to provide an implementation that allows the simulation of MPLS traffic with a pre-existing data plane. To achieve this, we have modified a couple of classes and files. See file [CHANGES.MD](CHANGES.MD) for details.
+> **Note**<br>
+> This repository is a fork of the [INET repository](https://github.com/inet-framework/inet). We have adapted a few things, mainly with respect to MPLS. The goal is to provide an implementation that allows the simulation of MPLS traffic with a pre-existing data plane. To achieve this, we have modified a couple of classes and files.<br>
+> Features:<br>
+> - Priority stack for MPLS forwarding rules<br>
+> - ECMP<br>
+> - Some fixes ...<br>
+> See file [CHANGES.MD](CHANGES.MD) for details.
 
 
 

--- a/src/inet/debugging.h
+++ b/src/inet/debugging.h
@@ -1,12 +1,19 @@
 #ifndef DEBUGGING_H_INCLUDED
 #define DEBUGGING_H_INCLUDED
-// File by Nikolaus Suess for debugging purposes
+//
+// Copyright (C) 2023 Nikolaus Suess
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+//
+// For debugging purposes only.
 
 #include <type_traits>
 
+// Debugging message.
 #define DEBUG(x) \
     std::cerr << __FILE__ << ":" << __LINE__ << ":" << __func__ << ": " << x << std::endl;
 
+// Allow to print the router name in debugging messages.
 #define IS_OF_TYPE(variable, type, todo) \
         (std::is_same<decltype(variable), type>::value ? variable->todo : "")
 
@@ -15,6 +22,7 @@
       IS_OF_TYPE(packet, Packet*, getArrivalGate()->getOwner()->getOwner()->getName()) << \
       "]: "
 
+// Print the packet tags.
 #include "inet/common/packet/Packet.h"
 inline void print_packet_tags(inet::Packet *msg){
     auto tags = msg->getTags();

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NodeConfigurator.cc
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NodeConfigurator.cc
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2012 OpenSim Ltd.
+// Modifications in 2023 by Nikolaus Suess.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //
@@ -100,14 +101,18 @@ void Ipv4NodeConfigurator::prepareAllInterfaces()
 void Ipv4NodeConfigurator::prepareInterface(NetworkInterface *networkInterface)
 {
 //    ASSERT(!networkInterface->getProtocolData<Ipv4InterfaceData>());
+    // CHANGES: Allow multiple loopback interfaces that have unique IP addresses.
     auto interfaceData = networkInterface->addProtocolData<Ipv4InterfaceData>();
     if (networkInterface->isLoopback()) {
         // we may reconfigure later it to be the routerId
         ++this->num_loopbacks_created;
+
+        assert(num_loopbacks_created > 0);
+        assert(num_loopbacks_created < 255);
+
         std::string address = std::string("127.0.0.")+std::to_string(num_loopbacks_created);
         DEBUG("Creating loopback interface with IP " << address);
         interfaceData->setIPAddress(Ipv4Address{address.c_str()});
-        //interfaceData->setIPAddress(Ipv4Address::LOOPBACK_ADDRESS);
         interfaceData->setNetmask(Ipv4Address::LOOPBACK_NETMASK);
         interfaceData->setMetric(1);
     }

--- a/src/inet/networklayer/configurator/ipv4/Ipv4NodeConfigurator.h
+++ b/src/inet/networklayer/configurator/ipv4/Ipv4NodeConfigurator.h
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2012 OpenSim Ltd.
+// Minor modifications in 2023 by Nikolaus Suess.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //
@@ -30,7 +31,7 @@ class INET_API Ipv4NodeConfigurator : public cSimpleModule, public ILifecycle, p
     ModuleRefByPar<IInterfaceTable> interfaceTable;
     ModuleRefByPar<IIpv4RoutingTable> routingTable;
     ModuleRefByPar<Ipv4NetworkConfigurator> networkConfigurator;
-    int num_loopbacks_created {0};
+    int num_loopbacks_created {0}; // number of loopback interfaces
 
   public:
     Ipv4NodeConfigurator();

--- a/src/inet/networklayer/mpls/LibTable.cc
+++ b/src/inet/networklayer/mpls/LibTable.cc
@@ -1,6 +1,7 @@
 //
 // Copyright (C) 2005 Vojtech Janota
 // Copyright (C) 2003 Xuan Thang Nguyen
+// Modifications by Nikolaus Suess in 2022-23.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //
@@ -177,6 +178,7 @@ void LibTable::removeLibEntry(int inLabel)
     ASSERT(false);
 }
 
+// Modified: Allow priority tag
 void LibTable::readTableFromXML(const cXMLElement *libtable)
 {
     using namespace xmlutils;

--- a/src/inet/networklayer/mpls/LibTable.h
+++ b/src/inet/networklayer/mpls/LibTable.h
@@ -44,6 +44,7 @@ class INET_API LibTable : public cSimpleModule
         std::string outInterface;
 
         int priority = 0;
+        int preference = 1;
     };
 
     struct LibEntry {
@@ -75,7 +76,7 @@ class INET_API LibTable : public cSimpleModule
             LabelOpVector& outLabel, std::string& outInterface, int& color);
 
     virtual int installLibEntry(int inLabel, std::string inInterface, const LabelOpVector& outLabel,
-            std::string outInterface, int color, int priority = 0);
+            std::string outInterface, int color, int priority = 0, int preference = 1);
 
     virtual void removeLibEntry(int inLabel);
 

--- a/src/inet/networklayer/mpls/LibTable.h
+++ b/src/inet/networklayer/mpls/LibTable.h
@@ -1,7 +1,7 @@
 //
 // Copyright (C) 2005 Vojtech Janota
 // Copyright (C) 2003 Xuan Thang Nguyen
-// Modifications by Nikolaus Suess in 2022
+// Modifications by Nikolaus Suess in 2022-23
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //
@@ -15,6 +15,7 @@
 #include "inet/networklayer/contract/ipv4/Ipv4Address.h"
 #include "inet/networklayer/ipv4/Ipv4Header_m.h"
 #include "inet/networklayer/mpls/ConstType.h"
+#include "inet/common/scenario/IScriptable.h"
 
 namespace inet {
 
@@ -35,7 +36,7 @@ typedef std::vector<LabelOp> LabelOpVector;
 /**
  * Represents the Label Information Base (LIB) for MPLS.
  */
-class INET_API LibTable : public cSimpleModule
+class INET_API LibTable : public cSimpleModule, public IScriptable
 {
   public:
 
@@ -44,7 +45,7 @@ class INET_API LibTable : public cSimpleModule
         std::string outInterface;
 
         int priority = 0;
-        int preference = 1;
+        float preference = 1;
     };
 
     struct LibEntry {
@@ -57,6 +58,9 @@ class INET_API LibTable : public cSimpleModule
         int color;
     };
 
+    static constexpr int   DEFAULT_PRIORITY   = 0;
+    static constexpr float DEFAULT_PREFERENCE = 1.0f;
+
   protected:
     int maxLabel;
     std::vector<LibEntry> lib;
@@ -68,7 +72,13 @@ class INET_API LibTable : public cSimpleModule
 
     // static configuration
     virtual void readTableFromXML(const cXMLElement *libtable);
+    virtual void processNewXmlEntry(const cXMLElement &entry);
+    // Check if the interface called "ifname" is up (true) or down (false)
     bool isInterfaceUp(const std::string& ifname);
+    // Process the <update-entry /> tag from scenario.xml to update a LibTable entry.
+    virtual void processCommand_updateEntry(const cXMLElement& node);
+    // Process the <delete-entry /> tag from scenario.xml to delete an entry from the LibTable.
+    virtual void processCommand_deleteEntry(const cXMLElement& node);
 
   public:
     // label management
@@ -76,9 +86,12 @@ class INET_API LibTable : public cSimpleModule
             LabelOpVector& outLabel, std::string& outInterface, int& color);
 
     virtual int installLibEntry(int inLabel, std::string inInterface, const LabelOpVector& outLabel,
-            std::string outInterface, int color, int priority = 0, int preference = 1);
+            std::string outInterface, int color, int priority = 0, float preference = 1.0f);
 
     virtual void removeLibEntry(int inLabel);
+
+    // process scenario.xml
+    virtual void processCommand(const cXMLElement& node) override;
 
     // utility
     static LabelOpVector pushLabel(int label);

--- a/src/inet/networklayer/mpls/Mpls.cc
+++ b/src/inet/networklayer/mpls/Mpls.cc
@@ -1,6 +1,7 @@
 //
 // Copyright (C) 2005 Vojtech Janota
 // Copyright (C) 2003 Xuan Thang Nguyen
+// Modifications by Nikolaus Suess in 2022-23.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //

--- a/src/inet/networklayer/mpls/Mpls.h
+++ b/src/inet/networklayer/mpls/Mpls.h
@@ -1,6 +1,7 @@
 //
 // Copyright (C) 2005 Vojtech Janota
 // Copyright (C) 2003 Xuan Thang Nguyen
+// Modifications by Nikolaus Suess in 2023.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //

--- a/src/inet/networklayer/rsvpte/RsvpClassifier.cc
+++ b/src/inet/networklayer/rsvpte/RsvpClassifier.cc
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2005 Vojtech Janota
+// Modifications by Nikolaus Suess in 2023.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //
@@ -78,7 +79,6 @@ bool RsvpClassifier::lookupLabel(Packet *packet, LabelOpVector& outLabel, std::s
             return false;
 
         bool ret = lt->resolveLabel("", elem.inLabel, outLabel, outInterface, color);
-        // TODO:
         // Actually push the MPLS label. Thus, we do not require extra rules.
         // NOTE: This might break other code ...
         if (ret){

--- a/src/inet/networklayer/rsvpte/RsvpTe.cc
+++ b/src/inet/networklayer/rsvpte/RsvpTe.cc
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2005 Vojtech Janota
+// Modifications by Nikolaus Suess in 2023.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //

--- a/src/inet/networklayer/ted/LinkStateRouting.cc
+++ b/src/inet/networklayer/ted/LinkStateRouting.cc
@@ -1,5 +1,6 @@
 //
 // Copyright (C) 2005 Vojtech Janota, Andras Varga
+// Modifications by Nikolaus Suess in 2023.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 //

--- a/src/inet/node/mpls/MplsRouter.ned
+++ b/src/inet/node/mpls/MplsRouter.ned
@@ -1,7 +1,13 @@
 //
+// Original code taken from RsvpMplsRouter.ned, by:
 // Copyright (C) 2020 OpenSim Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
+//
+// Modified (and turned into a new module called MplsRouter.ned) by:
+// Nikolaus Suess <nikolaus.suess@univie.ac.at>, 2023
+// Changes:
+// - added an additional loopback interface called mlo0, connected to the ml message dispatcher
 //
 
 package inet.node.mpls;
@@ -21,7 +27,7 @@ import inet.networklayer.ted.Ted;
 
 
 //
-// An RSVP-TE capable router.
+// An RSVP-TE capable router with an additional loopback interface called mlo0, connected to the ml message dispatcher.
 //
 // ~RsvpTe occupies the Transport layer; however, it is not a transport protocol
 // itself. ~RsvpTe uses transport protocols to route packets. ~Ted is used


### PR DESCRIPTION
 - Implementation of the `preference` attribute in the `LibTable` to load balance between multiple routing entries of the same priority. It is a `float` now (instead of an integer as initially planned) and `0.0f` is a valid value (that means "do not choose the rule").
- Replacement of `rand()` (from proof of concept) with `discrete_distribution`
- Allow modification of `preference` or `priority` attribute (of a rule) at runtime using the `ScenarioManager`.
- Allow deletion of a rule using the `ScenarioManager`. 
- Allow insertion of a rule using the `ScenarioManager`. 

In order to avoid code duplication here, `LibTable::readTableFromXML` was also split into 2 methods.